### PR TITLE
[BUGFIX] shorten regex in _gruntfile.js

### DIFF
--- a/app/templates/_gruntfile.js
+++ b/app/templates/_gruntfile.js
@@ -80,7 +80,7 @@ module.exports = function(grunt) {
           excludeBuiltins: true,
           patterns: [
             {
-              match: /{(app|deferred):{([\w|\-]{0,})}}/g,
+              match: /{(app|deferred):{([\w|\-]*)}}/g,
               replacement: function (match, type, file) {
 
                 // use regular file


### PR DESCRIPTION
Use * instead of {0,} to shorten the regex.